### PR TITLE
Awaitダメ！絶対！

### DIFF
--- a/src/main/scala/com/toyama/finagle/api/Api.scala
+++ b/src/main/scala/com/toyama/finagle/api/Api.scala
@@ -18,7 +18,7 @@ import io.circe.parser._
 import scala.language.postfixOps
 
 object Api extends App {
-  def requestToDsp(host: String, port: String, json: String): Future[Response] = {
+  def requestToDsp(host: String, port: String, json: String): Future[Either[Throwable, Response]] = {
     val client: Service[Request, Response] = Http.client
       .withRequestTimeout(100 milliseconds)
       .newService(s"""$host:$port""")
@@ -27,49 +27,34 @@ object Api extends App {
     request.setContentString(json)
     request.setContentTypeJson()
 
-    val response: Future[Response] = client(request)
-    response
+    client(request)
+      .map(Right(_))
+      .handle { case t => Left(t) } // Requestが失敗しても、FutureはFailureにならないようにする
   }
 
   val response: Endpoint[SspAdResBody] = post("v1" :: "ad" :: jsonBody[SspAdReqBody]) {
     (request: SspAdReqBody) =>
       val listOfFutures = List(requestToDsp("ss.matome-plus.info", "80", request.toString))
-      //      val futureOfList: Future[Seq[Response]] = Future.collect(listOfFutures)
-//      val a = for {
-//        responseNel <- listOfFutures.par.flatMap(awaitEachFuture).toList.toNel
-//      } yield {
-//        val dspAdResBodyList = for {
-//          response <- responseNel.toList
-//          dspAdResBody <- decode[DspAdResBody](response.contentString).toOption
-//        } yield dspAdResBody
-//
-//        dspAdResBodyList.toNel.map { dspAdResBodyNel =>
-//          Ok(
-//            SspAdResBody(dspAdResBodyNel.toList.maxBy(body => body.price).url)
-//          )
-//        }.getOrElse(NoContent)
-//      }
-//      a.getOrElse(NoContent)
+      val futureOfList = Future.collect(listOfFutures)
 
-      println(awaitEachFuture(listOfFutures.head))
-//      println(listOfFutures.par.flatMap(awaitEachFuture).toList.toNel)
-      val dspAdResList: List[DspAdResBody] = (for {
-        responseNel <- OptionT.fromOption[List](listOfFutures.par.flatMap(awaitEachFuture).toList.toNel)
-        response <- OptionT.liftF(responseNel.toList)
-        dspAdResBody <- OptionT.fromOption(decode[DspAdResBody](response.contentString).toOption)
-      } yield dspAdResBody).value.flatten
+      futureOfList.map { listOfEither =>
+        val responsesReceivedInTime = listOfEither.flatMap(_.toOption)
 
-      dspAdResList.toNel.map { dspAdResNel =>
-        Ok(
-          SspAdResBody(dspAdResNel.toList.maxBy(body => body.price).url)
-        )
-      }.getOrElse(NoContent)
+        val dspAdResList: List[DspAdResBody] = (for {
+          responseNel <- OptionT.fromOption[List](responsesReceivedInTime.toList.toNel)
+          response <- OptionT.liftF(responseNel.toList)
+          dspAdResBody <- OptionT.fromOption(decode[DspAdResBody](response.contentString).toOption)
+        } yield dspAdResBody).value.flatten
+
+        dspAdResList.toNel.map { dspAdResNel =>
+          Ok(
+            SspAdResBody(dspAdResNel.toList.maxBy(body => body.price).url)
+          )
+        }.getOrElse(NoContent)
+      }
   }
 
   val server: ListeningServer = Http.server.serve(":9000", response.toServiceAs[Application.Json])
 
   Await.ready(server)
-
-  private def awaitEachFuture(f: Future[Response]): Option[Response] =
-    Try(Await.result(f, 1000 millisecond)).toOption
 }


### PR DESCRIPTION
PlaySSPの時とほぼ同じPR。

h2loadでベンチマークも取ってみました。
210req/sなのでかなり速いですね！Playよりずっと速いような気がする。

（注: このベンチマークを取った時は、DSPから応答がない場合はNoContentの代わりにBadRequestを返すようにしていました。1000Request中141が4xx系になっているのはそのためです。）

```
$ h2load -p http/1.1 -H Content-Type:application/json -d sample.json -c 100 -n 1000 http://localhost:9000/v1/ad
starting benchmark...
spawning thread #0: 100 total client(s). 1000 total requests
Application protocol: http/1.1
progress: 10% done
progress: 20% done
progress: 30% done
progress: 40% done
progress: 50% done
progress: 60% done
progress: 70% done
progress: 80% done
progress: 90% done
progress: 100% done

finished in 4.75s, 210.64 req/s, 30.79KB/s
requests: 1000 total, 1000 started, 1000 done, 859 succeeded, 141 failed, 0 errored, 0 timeout
status codes: 859 2xx, 0 3xx, 141 4xx, 0 5xx
traffic: 146.17KB (149681) total, 81.94KB (83911) headers (space savings 0.00%), 29.36KB (30065) data
                     min         max         mean         sd        +/- sd
time for request:    15.70ms       2.38s    363.72ms    654.46ms    89.90%
time for connect:      546us      4.49ms      2.50ms      1.02ms    60.00%
time to 1st byte:      2.25s       3.13s       2.43s    144.92ms    72.00%
req/s           :       2.11        3.10        2.75        0.14    88.00%
```